### PR TITLE
now with correct intermediate array results

### DIFF
--- a/src/fixtures/blockOfStreets.xml
+++ b/src/fixtures/blockOfStreets.xml
@@ -12,17 +12,17 @@
 				</URL>
 			</CDATAURLS>
 			<TrackingEvents>
-				<Tracking event="start">
+				<Tracking event="start" underway="false">
 					<URL id="number0">
 						<![CDATA[http://serverland.net/ad/start]]>
 					</URL>
 					</Tracking>
-				<Tracking event="midpoint">
+				<Tracking event="midpoint" underway="true">
 					<URL id="number1">
 						<![CDATA[http://serverland.net/ad/midpoint]]>
 					</URL>
 				</Tracking>
-				<Tracking event="complete">
+				<Tracking event="complete" underway="false">
 					<URL id="number2">
 						<![CDATA[http://serverland.net/ad/complete]]>
 					</URL>

--- a/src/xpath.spec.js
+++ b/src/xpath.spec.js
@@ -162,6 +162,24 @@ describe("xpath", function() {
 			});
 		});
 
+		it("//TrackingEvents/Tracking[@underway=false]", function(done) {
+			parseString(file, function (err, json) {
+				expect(err).to.equal(null);
+				expect(xpath.find(json,".//TrackingEvents/Tracking[@underway='false']").length).to.equal(2);
+				expect(xpath.jsonText(xpath.find(json,".//TrackingEvents/Tracking[@underway='false']")[0])).to.equal("\n\t\t\t\t\t\thttp://serverland.net/ad/start\n\t\t\t\t\t");
+				done();
+			});
+		});
+
+		it("//TrackingEvents/Tracking[@underway=false]/URL", function(done) {
+			parseString(file, function (err, json) {
+				expect(err).to.equal(null);
+				expect(xpath.find(json,".//TrackingEvents/Tracking[@underway='false']/URL").length).to.equal(2);
+				expect(xpath.jsonText(xpath.find(json,".//TrackingEvents/Tracking[@underway='false']/URL")[0])).to.equal("\n\t\t\t\t\t\thttp://serverland.net/ad/start\n\t\t\t\t\t");
+				done();
+			});
+		});
+
     it('can find /vast/nest/val', function(done) {
 			parseString('<vast><nest><val>2</val></nest></vast>', function(err, json) {
 				expect(xpath.find(json,'/vast/nest/val').length).to.equal(1);


### PR DESCRIPTION
i ran into a situation with the "/Element[key=value]" matching logic where `find("//a/b[@c='d']/e")` would not return all possible results if there were multiple hits not just for `//a` and/or `/e` in the end, but for `b[@c='d']/e`. relevant testcases and new code in separate commits below. 

kinda messed up and put some performance improvements into the second commit as well, but they're easy to tell apart from the testcase-fixing parts, i hope (i switched out `String.prototype.replace(<RegExp>,'')` for `String.prototype.replace(<Template String>,'')` where possible).

hth :)